### PR TITLE
fix(websocket-demo): resolve Firefox audio stream hang and prevent AudioContext leaks

### DIFF
--- a/gemini-live-ephemeral-tokens-websocket/frontend/mediaUtils.js
+++ b/gemini-live-ephemeral-tokens-websocket/frontend/mediaUtils.js
@@ -22,6 +22,9 @@ class AudioStreamer {
    * @param {string} deviceId - Optional device ID for specific microphone
    */
   async start(deviceId = null) {
+    if (this.isStreaming) {
+      return;
+    }
     try {
       // Build audio constraints
       const audioConstraints = {
@@ -117,6 +120,17 @@ class AudioStreamer {
     }
 
     console.log("🛑 Audio streaming stopped");
+  }
+
+  /**
+   * Clean up resources
+   */
+  destroy() {
+    this.stop();
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = null;
+    }
   }
 
   /**
@@ -410,6 +424,7 @@ class AudioPlayer {
     this.workletNode = null;
     this.gainNode = null;
     this.isInitialized = false;
+    this.initPromise = null;
     this.volume = 1.0;
     this.sampleRate = 24000; // Gemini outputs at 24kHz
   }
@@ -419,44 +434,50 @@ class AudioPlayer {
    */
   async init() {
     if (this.isInitialized) return;
+    if (this.initPromise) return this.initPromise;
 
-    try {
-      // Create audio context at 24kHz to match Gemini
-      this.audioContext = new (window.AudioContext ||
-        window.webkitAudioContext)({
-        sampleRate: this.sampleRate,
-      });
+    this.initPromise = (async () => {
+      try {
+        // Create audio context at 24kHz to match Gemini
+        this.audioContext = new (window.AudioContext ||
+          window.webkitAudioContext)({
+          sampleRate: this.sampleRate,
+        });
 
-      // Resume immediately since we are in a user-initiated gesture
-      if (this.audioContext.state === "suspended") {
-        await this.audioContext.resume();
+        // Resume immediately since we are in a user-initiated gesture
+        if (this.audioContext.state === "suspended") {
+          await this.audioContext.resume();
+        }
+
+        // Load the audio worklet from external file
+        await this.audioContext.audioWorklet.addModule(
+          "audio-processors/playback.worklet.js"
+        );
+
+        // Create worklet node
+        this.workletNode = new AudioWorkletNode(
+          this.audioContext,
+          "pcm-processor"
+        );
+
+        // Create gain node for volume control
+        this.gainNode = this.audioContext.createGain();
+        this.gainNode.gain.value = this.volume;
+
+        // Connect nodes
+        this.workletNode.connect(this.gainNode);
+        this.gainNode.connect(this.audioContext.destination);
+
+        this.isInitialized = true;
+        console.log("🔊 Audio player initialized");
+      } catch (error) {
+        console.error("Failed to initialize audio player:", error);
+        this.initPromise = null;
+        throw error;
       }
+    })();
 
-      // Load the audio worklet from external file
-      await this.audioContext.audioWorklet.addModule(
-        "audio-processors/playback.worklet.js"
-      );
-
-      // Create worklet node
-      this.workletNode = new AudioWorkletNode(
-        this.audioContext,
-        "pcm-processor"
-      );
-
-      // Create gain node for volume control
-      this.gainNode = this.audioContext.createGain();
-      this.gainNode.gain.value = this.volume;
-
-      // Connect nodes
-      this.workletNode.connect(this.gainNode);
-      this.gainNode.connect(this.audioContext.destination);
-
-      this.isInitialized = true;
-      console.log("🔊 Audio player initialized");
-    } catch (error) {
-      console.error("Failed to initialize audio player:", error);
-      throw error;
-    }
+    return this.initPromise;
   }
 
   /**
@@ -524,5 +545,6 @@ class AudioPlayer {
       this.audioContext = null;
     }
     this.isInitialized = false;
+    this.initPromise = null;
   }
 }

--- a/gemini-live-ephemeral-tokens-websocket/frontend/mediaUtils.js
+++ b/gemini-live-ephemeral-tokens-websocket/frontend/mediaUtils.js
@@ -12,6 +12,7 @@ class AudioStreamer {
     this.audioContext = null;
     this.audioWorklet = null;
     this.mediaStream = null;
+    this.audioSource = null;
     this.isStreaming = false;
     this.sampleRate = 16000; // Gemini requires 16kHz
   }
@@ -40,44 +41,51 @@ class AudioStreamer {
         audio: audioConstraints,
       });
 
-      // Create audio context at 16kHz
-      this.audioContext = new (window.AudioContext ||
-        window.webkitAudioContext)({
-        sampleRate: this.sampleRate,
-      });
+      // Create audio context at 16kHz if it doesn't exist
+      if (!this.audioContext) {
+        this.audioContext = new (window.AudioContext ||
+          window.webkitAudioContext)({
+          sampleRate: this.sampleRate,
+        });
 
-      // Load the audio worklet module
-      await this.audioContext.audioWorklet.addModule(
-        "audio-processors/capture.worklet.js"
-      );
+        // Load the audio worklet module
+        await this.audioContext.audioWorklet.addModule(
+          "audio-processors/capture.worklet.js"
+        );
 
-      // Create the audio worklet node
-      this.audioWorklet = new AudioWorkletNode(
-        this.audioContext,
-        "audio-capture-processor"
-      );
+        // Create the audio worklet node
+        this.audioWorklet = new AudioWorkletNode(
+          this.audioContext,
+          "audio-capture-processor"
+        );
 
-      // Set up message handling from the worklet
-      this.audioWorklet.port.onmessage = (event) => {
-        if (!this.isStreaming) return;
+        // Set up message handling from the worklet
+        this.audioWorklet.port.onmessage = (event) => {
+          if (!this.isStreaming) return;
 
-        if (event.data.type === "audio") {
-          const inputData = event.data.data;
-          const pcmData = this.convertToPCM16(inputData);
-          const base64Audio = this.arrayBufferToBase64(pcmData);
+          if (event.data.type === "audio") {
+            const inputData = event.data.data;
+            const pcmData = this.convertToPCM16(inputData);
+            const base64Audio = this.arrayBufferToBase64(pcmData);
 
-          // Send to Gemini
-          if (this.client && this.client.connected) {
-            this.client.sendAudioMessage(base64Audio);
+            // Send to Gemini
+            if (this.client && this.client.connected) {
+              this.client.sendAudioMessage(base64Audio);
+            }
           }
-        }
-      };
+        };
+      }
+
+      // Ensure the context is running (it might be suspended by the browser or by us in stop())
+      if (this.audioContext.state === "suspended") {
+        await this.audioContext.resume();
+      }
 
       // Connect the audio graph
-      const source = this.audioContext.createMediaStreamSource(
+      this.audioSource = this.audioContext.createMediaStreamSource(
         this.mediaStream
       );
-      source.connect(this.audioWorklet);
+      this.audioSource.connect(this.audioWorklet);
 
       this.isStreaming = true;
       console.log("🎤 Audio streaming started");
@@ -94,15 +102,13 @@ class AudioStreamer {
   stop() {
     this.isStreaming = false;
 
-    if (this.audioWorklet) {
-      this.audioWorklet.disconnect();
-      this.audioWorklet.port.close();
-      this.audioWorklet = null;
+    if (this.audioSource) {
+      this.audioSource.disconnect();
+      this.audioSource = null;
     }
 
-    if (this.audioContext) {
-      this.audioContext.close();
-      this.audioContext = null;
+    if (this.audioContext && this.audioContext.state === "running") {
+      this.audioContext.suspend();
     }
 
     if (this.mediaStream) {
@@ -420,6 +426,11 @@ class AudioPlayer {
         window.webkitAudioContext)({
         sampleRate: this.sampleRate,
       });
+
+      // Resume immediately since we are in a user-initiated gesture
+      if (this.audioContext.state === "suspended") {
+        await this.audioContext.resume();
+      }
 
       // Load the audio worklet from external file
       await this.audioContext.audioWorklet.addModule(

--- a/gemini-live-ephemeral-tokens-websocket/frontend/script.js
+++ b/gemini-live-ephemeral-tokens-websocket/frontend/script.js
@@ -208,6 +208,12 @@ function disconnect() {
   if (state.video.streamer) state.video.streamer.stop();
   if (state.screen.capture) state.screen.capture.stop();
 
+  // Clean up audio player
+  if (state.audio.player) {
+    state.audio.player.destroy();
+    state.audio.player = null;
+  }
+
   // Reset states
   state.audio.isStreaming = false;
   state.video.isStreaming = false;

--- a/gemini-live-ephemeral-tokens-websocket/frontend/script.js
+++ b/gemini-live-ephemeral-tokens-websocket/frontend/script.js
@@ -203,8 +203,11 @@ function disconnect() {
     state.client = null;
   }
 
-  // Stop all streams
-  if (state.audio.streamer) state.audio.streamer.stop();
+  // Clean up audio streamer
+  if (state.audio.streamer) {
+    state.audio.streamer.destroy();
+    state.audio.streamer = null;
+  }
   if (state.video.streamer) state.video.streamer.stop();
   if (state.screen.capture) state.screen.capture.stop();
 


### PR DESCRIPTION
This PR fixes two issues in the `gemini-live-ephemeral-tokens-websocket` example:

1.  **Firefox Text-only Hang**: Toggling the microphone off (`[Microphone off]`) in Firefox caused the model to stop responding to subsequent text inputs. This occurred because abruptly closing the `AudioContext` while media tracks were active terminated the audio stream in an unclean state. The Gemini server's Voice Activity Detection (VAD) was left waiting for the stream to finish, keeping the turn open. Any subsequent text was appended to this open turn, preventing a response.
    *   *Fix*: Refactored `AudioStreamer` to **suspend/resume** a single `AudioContext` instead of closing and recreating it, allowing the stream to pause cleanly.
2.  **AudioContext Leak**: Reconnecting leaked a 24kHz `AudioContext` from the `AudioPlayer` every time.
    *   *Fix*: Properly destroy the `AudioPlayer` and close its context on disconnect.

---

### Proof of the Issue (Unresponsive text after Mic Off)
As shown below, text messages sent after turning the microphone off received no response. Once the microphone was turned back on and activated, the server finally committed the turn and responded to the queued text query.

<img width="600" alt="Firefox VAD Hang" src="https://github.com/user-attachments/assets/1c0f7358-b648-4510-af93-6ebb3e0b5bb4" />